### PR TITLE
Fix to hide "Content" dropdown #12

### DIFF
--- a/Cultiv.Tabify/tabify.css
+++ b/Cultiv.Tabify/tabify.css
@@ -143,3 +143,9 @@
     width: 100%;
 }
 
+
+/* hide the "Content" dropdown (avoid confusion) */
+.dropdown-menu.umb-sub-views-nav-item__anchor_dropdown.ng-scope {
+    display:none;
+}
+


### PR DESCRIPTION
This disables the dropdown when tabs are used. Solved irritations users had with the "new tabs and the button" for us.